### PR TITLE
feat: Implement dynamic section loading and footer interactions

### DIFF
--- a/app/src/main/java/com/example/stylefeed/MainActivity.kt
+++ b/app/src/main/java/com/example/stylefeed/MainActivity.kt
@@ -4,7 +4,6 @@ import ProductScreen
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import com.airbnb.mvrx.compose.mavericksViewModel
 import com.example.stylefeed.ui.theme.FashionContentTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -12,7 +11,6 @@ import dagger.hilt.android.AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-//        enableEdgeToEdge()
         setContent {
             FashionContentTheme {
                 ProductScreen()

--- a/app/src/main/java/com/example/stylefeed/base/UiContract.kt
+++ b/app/src/main/java/com/example/stylefeed/base/UiContract.kt
@@ -8,7 +8,7 @@ object NoEvent : UiEvent
 object NoEffect : UiEffect
 
 sealed class CounterEvent : UiEvent {
-    object Increment : CounterEvent()
+    data object Increment : CounterEvent()
 }
 
 sealed class CounterEffect : UiEffect {

--- a/app/src/main/java/com/example/stylefeed/data/remote/product_api/mapper/SectionListMapper.kt
+++ b/app/src/main/java/com/example/stylefeed/data/remote/product_api/mapper/SectionListMapper.kt
@@ -4,4 +4,4 @@ import com.example.stylefeed.data.remote.product_api.dto.RootDto
 import com.example.stylefeed.domain.model.Section
 
 fun RootDto.toDomain(): List<Section> =
-    data?.map { it.toDomain() } ?: emptyList()
+    data.map { it.toDomain() } ?: emptyList()

--- a/app/src/main/java/com/example/stylefeed/data/remote/product_api/mapper/SectionStateMapper.kt
+++ b/app/src/main/java/com/example/stylefeed/data/remote/product_api/mapper/SectionStateMapper.kt
@@ -1,0 +1,28 @@
+package com.example.stylefeed.data.remote.product_api.mapper
+
+import com.example.stylefeed.domain.model.Content
+import com.example.stylefeed.domain.model.Section
+import com.example.stylefeed.domain.model.SectionState
+
+fun List<Section>.toSectionStates(): List<SectionState> {
+    return map { section ->
+        val totalCount = when (section.content) {
+            is Content.GridContent -> section.content.products.size
+            is Content.ScrollContent -> section.content.products.size
+            is Content.BannerContent -> section.content.banners.size
+            is Content.StyleContent -> section.content.styles.size
+            else -> 0
+        }
+
+        val visibleCount = when (section.content) {
+            is Content.GridContent -> minOf(6, totalCount)
+            else -> totalCount // Grid가 아닌 경우엔 모두 보여줌
+        }
+
+        SectionState(
+            section = section,
+            visibleItemCount = visibleCount,
+            totalItemCount = totalCount
+        )
+    }
+}

--- a/app/src/main/java/com/example/stylefeed/domain/model/SectionState.kt
+++ b/app/src/main/java/com/example/stylefeed/domain/model/SectionState.kt
@@ -1,0 +1,15 @@
+package com.example.stylefeed.domain.model
+
+data class SectionState(
+    val section: Section,
+    val visibleItemCount: Int,  // 현재 보여지는 개수
+    val totalItemCount: Int     // 전체 데이터 개수
+) {
+    val visibleContent: Content
+        get() = when (val content = section.content) {
+            is Content.GridContent -> content.copy(products = content.products.take(visibleItemCount))
+            is Content.ScrollContent -> content.copy(products = content.products.take(visibleItemCount))
+            is Content.StyleContent -> content.copy(styles = content.styles.take(visibleItemCount))
+            else -> content
+        }
+}

--- a/app/src/main/java/com/example/stylefeed/domain/usecase/GetSectionsUseCase.kt
+++ b/app/src/main/java/com/example/stylefeed/domain/usecase/GetSectionsUseCase.kt
@@ -1,12 +1,18 @@
 package com.example.stylefeed.domain.usecase
 
-import com.example.stylefeed.domain.model.Section
+import com.example.stylefeed.data.remote.product_api.mapper.toSectionStates
+import com.example.stylefeed.domain.model.SectionState
 import com.example.stylefeed.domain.repository.ProductRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class GetSectionsUseCase @Inject constructor(
     private val repository: ProductRepository
 ) {
-    operator fun invoke(): Flow<List<Section>> = repository.getSections()
+    operator fun invoke(): Flow<List<SectionState>> {
+        return repository.getSections().map { sections ->
+            sections.toSectionStates()
+        }
+    }
 }

--- a/app/src/main/java/com/example/stylefeed/ui/common/Footer.kt
+++ b/app/src/main/java/com/example/stylefeed/ui/common/Footer.kt
@@ -7,12 +7,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.example.stylefeed.domain.model.Footer
+import com.example.stylefeed.domain.model.FooterType
 
 @Composable
-fun Footer(footer: Footer) {
+fun Footer(
+    footer: Footer,
+    onFooterClick: (FooterType) -> Unit
+) {
     Button(
-        onClick = { /* REFRESH 또는 MORE 처리 로직 */ },
-        modifier = Modifier.fillMaxWidth().padding(16.dp)
+        onClick = { onFooterClick(footer.type) },
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
     ) {
         Text(footer.title)
     }

--- a/app/src/main/java/com/example/stylefeed/ui/screens/SectionView.kt
+++ b/app/src/main/java/com/example/stylefeed/ui/screens/SectionView.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import com.example.stylefeed.domain.model.Content
+import com.example.stylefeed.domain.model.FooterType
 import com.example.stylefeed.domain.model.Section
+import com.example.stylefeed.domain.model.SectionState
 import com.example.stylefeed.ui.common.BannerSlider
 import com.example.stylefeed.ui.common.Footer
 import com.example.stylefeed.ui.common.Header
@@ -13,16 +15,24 @@ import com.example.stylefeed.ui.common.ProductHorizontalList
 import com.example.stylefeed.ui.common.StyleGrid
 
 @Composable
-fun SectionView(section: Section, isSectionVisible: Boolean) {
+fun SectionView(
+    sectionState: SectionState,
+    isSectionVisible: Boolean,
+    onFooterClick: (SectionState, FooterType) -> Unit
+) {
     Column {
-        section.header?.let { Header(header = it) }
-        when (val content = section.content) {
+        sectionState.section.header?.let { Header(header = it) }
+        when (val content = sectionState.visibleContent) {
             is Content.BannerContent -> BannerSlider(content.banners, isVisible = isSectionVisible)
             is Content.GridContent -> ProductGrid(content.products)
             is Content.ScrollContent -> ProductHorizontalList(content.products)
             is Content.StyleContent -> StyleGrid(content.styles)
             is Content.UnknownContent -> Text("지원하지 않는 컨텐츠입니다.")
         }
-        section.footer?.let { Footer(it) }
+        sectionState.section.footer?.let { footer ->
+            Footer(footer) { footerType ->
+                onFooterClick(sectionState, footerType)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/stylefeed/ui/screens/SectionsList.kt
+++ b/app/src/main/java/com/example/stylefeed/ui/screens/SectionsList.kt
@@ -13,16 +13,18 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.layout.onGloballyPositioned
-import com.example.stylefeed.domain.model.Section
+import com.example.stylefeed.domain.model.FooterType
+import com.example.stylefeed.domain.model.SectionState
 
 private const val FadeAnimationDurationMillis = 600
 
 @Composable
 fun SectionsList(
-    sections: List<Section>,
+    sectionStates: List<SectionState>,
     isVisible: Boolean,
     listState: LazyListState,
     sectionHeights: MutableMap<Int, Float>,
+    onFooterClick: (SectionState, FooterType) -> Unit
 ) {
     val visibleBannerIndices by remember {
         derivedStateOf {
@@ -35,8 +37,8 @@ fun SectionsList(
             modifier = if (visible) Modifier.fillMaxSize() else Modifier.fillMaxSize().alpha(0f),
             state = listState
         ) {
-            sections.forEachIndexed { index, section ->
-                item(key = section.hashCode()) {
+            sectionStates.forEachIndexed { index, sectionState ->
+                item(key = sectionState.hashCode()) {
                     Box(
                         Modifier.onGloballyPositioned {
                             sectionHeights[index] = it.size.height.toFloat()
@@ -44,7 +46,7 @@ fun SectionsList(
                     ) {
                         val bannerVisible = visibleBannerIndices.contains(index)
 
-                        SectionView(section, bannerVisible)
+                        SectionView(sectionState, bannerVisible,onFooterClick = onFooterClick)
                     }
                 }
             }

--- a/app/src/main/java/com/example/stylefeed/ui/screens/productscreen.kt
+++ b/app/src/main/java/com/example/stylefeed/ui/screens/productscreen.kt
@@ -21,6 +21,7 @@ import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.compose.collectAsState
 import com.airbnb.mvrx.compose.mavericksViewModel
 import com.example.stylefeed.ui.screens.SectionsList
+import com.example.stylefeed.ui.viewmodel.ProductEvent
 import com.example.stylefeed.ui.viewmodel.ProductState
 import com.example.stylefeed.ui.viewmodel.ProductViewModel
 import kotlinx.coroutines.delay
@@ -62,7 +63,7 @@ fun ProductScreen(viewModel: ProductViewModel = mavericksViewModel()) {
             val sections = sectionsAsync.invoke()
             val sectionHeight = sectionHeights[firstIndex] ?: 0f
             currentStickyHeader.value = if (sectionHeight > deviceHeightPx && offset > 0) {
-                sections?.getOrNull(firstIndex)?.header?.title
+                sections?.getOrNull(firstIndex)?.section?.header?.title
             } else null
         }
     }
@@ -72,10 +73,14 @@ fun ProductScreen(viewModel: ProductViewModel = mavericksViewModel()) {
             is Loading -> CircularProgressIndicator(Modifier.align(Alignment.Center))
             is Success -> {
                 SectionsList(
-                    sections = sections(),
+                    sectionStates = sections(),
                     isVisible = isVisible.value,
                     listState = listState,
-                    sectionHeights = sectionHeights
+                    sectionHeights = sectionHeights,
+                    { sectionState, footerType ->
+                        val sectionIndex = sections().indexOf(sectionState)
+                        viewModel.onEvent(ProductEvent.OnFooterClicked(sectionIndex, footerType))
+                    }
                 )
                 StickyHeader(headerText = currentStickyHeader.value)
             }

--- a/app/src/main/java/com/example/stylefeed/ui/viewmodel/ProductEvent.kt
+++ b/app/src/main/java/com/example/stylefeed/ui/viewmodel/ProductEvent.kt
@@ -1,0 +1,14 @@
+package com.example.stylefeed.ui.viewmodel
+
+import com.example.stylefeed.base.UiEffect
+import com.example.stylefeed.base.UiEvent
+import com.example.stylefeed.domain.model.FooterType
+
+sealed class ProductEvent : UiEvent {
+    data class OnFooterClicked(val sectionIndex: Int, val footerType: FooterType) : ProductEvent()
+}
+
+sealed class ProductEffect : UiEffect {
+    data object ShowContentRefreshedToast : ProductEffect()
+    data object ShowNoMoreContentToast : ProductEffect()
+}

--- a/app/src/main/java/com/example/stylefeed/ui/viewmodel/ProductViewModel.kt
+++ b/app/src/main/java/com/example/stylefeed/ui/viewmodel/ProductViewModel.kt
@@ -3,26 +3,27 @@ package com.example.stylefeed.ui.viewmodel
 import com.airbnb.mvrx.Async
 import com.airbnb.mvrx.MavericksState
 import com.airbnb.mvrx.MavericksViewModelFactory
+import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.hilt.AssistedViewModelFactory
 import com.airbnb.mvrx.hilt.hiltMavericksViewModelFactory
 import com.example.stylefeed.base.BaseMviViewModel
-import com.example.stylefeed.base.CounterEffect
-import com.example.stylefeed.base.CounterEvent
-import com.example.stylefeed.domain.model.Section
+import com.example.stylefeed.domain.model.Content
+import com.example.stylefeed.domain.model.FooterType
+import com.example.stylefeed.domain.model.SectionState
 import com.example.stylefeed.domain.usecase.GetSectionsUseCase
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 
 data class ProductState(
-    val sections: Async<List<Section>> = Uninitialized,
+    val sections: Async<List<SectionState>> = Uninitialized
 ) : MavericksState
 
 class ProductViewModel @AssistedInject constructor(
     @Assisted initialState: ProductState,
     private val getSectionsUseCase: GetSectionsUseCase,
-) : BaseMviViewModel<ProductState, CounterEvent, CounterEffect>(initialState) {
+) : BaseMviViewModel<ProductState, ProductEvent, ProductEffect>(initialState) {
 
     init {
         fetchSections()
@@ -31,7 +32,7 @@ class ProductViewModel @AssistedInject constructor(
 
     private fun fetchSections() {
         getSectionsUseCase()
-            .execute { copy(sections = it) }
+            .execute { copy(sections = it) } // 결과를 state의 sections에 저장
     }
 
     @AssistedFactory
@@ -42,9 +43,51 @@ class ProductViewModel @AssistedInject constructor(
     companion object :
         MavericksViewModelFactory<ProductViewModel, ProductState> by hiltMavericksViewModelFactory()
 
-    override fun onEvent(event: CounterEvent) {
-
+    override fun onEvent(event: ProductEvent) {
+        when (event) {
+            is ProductEvent.OnFooterClicked -> handleFooterEvent(
+                event.sectionIndex,
+                event.footerType
+            )
+        }
     }
 
+    private fun handleFooterEvent(sectionIndex: Int, footerType: FooterType) {
+        withState { currentState ->
+            val updatedSections = currentState.sections()?.toMutableList() ?: return@withState
+
+            val sectionState = updatedSections[sectionIndex]
+
+            when (footerType) {
+                FooterType.MORE -> {
+                    val newVisibleCount = (sectionState.visibleItemCount + 3).coerceAtMost(sectionState.totalItemCount)
+                    updatedSections[sectionIndex] = sectionState.copy(visibleItemCount = newVisibleCount)
+                }
+
+                FooterType.REFRESH -> {
+                    // 여기서 shuffled 호출 (setState 외부에서!)
+                    val shuffledContent = sectionState.section.content.shuffleContent()
+                    val updatedSection = sectionState.section.copy(content = shuffledContent)
+                    updatedSections[sectionIndex] = sectionState.copy(section = updatedSection)
+                }
+
+                else -> Unit
+            }
+
+            // 최종 setState는 shuffle 등 랜덤성 작업 이후 결과값을 넣어주므로 순수함수 조건 충족
+            setState {
+                copy(sections = Success(updatedSections))
+            }
+        }
+    }
 
 }
+private fun Content.shuffleContent(): Content = when (this) {
+    is Content.GridContent -> copy(products = products.shuffled())
+    is Content.ScrollContent -> copy(products = products.shuffled())
+    is Content.BannerContent -> copy(banners = banners.shuffled())
+    is Content.StyleContent -> copy(styles = styles.shuffled())
+    else -> this
+}
+
+


### PR DESCRIPTION
This commit introduces dynamic loading of section content and enhances footer interactions within sections.

-   **ProductEvent and ProductEffect**:
    -   Created `ProductEvent` to manage section interactions, including `OnFooterClicked`.
    -   Introduced `ProductEffect` for UI feedback such as content refresh or no more content.
-   **SectionState**:
    -   Implemented `SectionState` to handle visible items, managing the display count and total content.
-   **SectionStateMapper**:
    -   Added `toSectionStates` to map section data to `SectionState` objects, defining initial visible items.
-   **SectionView**:
    -   Modified to display content based on `SectionState`, adapting to the number of visible items.
    -   Added `onFooterClick` callback to handle footer actions like "MORE" or "REFRESH."
-   **ProductViewModel**:
    -   Changed `sections` property type to `List<SectionState>`.
    -   Implemented `OnFooterClicked` event to handle footer interactions.
    -   Added logic to update `SectionState` with new visible counts on "MORE" clicks and shuffle content on "REFRESH."
-   **GetSectionsUseCase**:
    -   Updated to return a `Flow<List<SectionState>>`, utilizing the new mapper for section states.
-   **ProductScreen**:
    -   Updated to work with `SectionState`, fetching and displaying data accordingly.
    -   Added `onFooterClick` event to send event to view model.
-   **Footer**:
    -   Enhanced the `Footer` composable with `onFooterClick` to send footer click information to viewmodel.
-   **SectionsList**:
    -   Updated to use `SectionState`, adjusting display and visibility of content.
-   **UiContract**:
    - Updated `CounterEvent` with `data object`
-   **Removed**:
    - Unused `toDomain` file deleted
    - Unnecessary `enableEdgeToEdge` function call in `MainActivity` deleted.