### PR TITLE
feat: Implement product refresh with loading state and notification

### DIFF
--- a/app/src/main/java/com/example/stylefeed/ui/screens/product/ProductScreen.kt
+++ b/app/src/main/java/com/example/stylefeed/ui/screens/product/ProductScreen.kt
@@ -19,7 +19,6 @@ import com.example.stylefeed.ui.screens.product.interactions.handleFooterClick
 import com.example.stylefeed.ui.screens.product.viewmodel.ProductEffect
 import com.example.stylefeed.ui.screens.product.viewmodel.ProductState
 import com.example.stylefeed.ui.screens.product.viewmodel.ProductViewModel
-import kotlinx.coroutines.delay
 
 
 @Composable
@@ -31,7 +30,7 @@ fun ProductScreen(viewModel: ProductViewModel = mavericksViewModel()) {
     val apiError by viewModel.collectAsState(ProductState::apiError)
     val sectionHeights = remember { mutableStateMapOf<Int, Float>() }
 
-    val sectionLoadingMap by viewModel.collectAsState(ProductState::sectionLoadingMap)
+    val sectionLoadingMap by viewModel.collectAsState(ProductState::sectionUiLoadingMap)
     var refreshBannerTrigger by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {

--- a/app/src/main/java/com/example/stylefeed/ui/screens/product/ProductScreenContent.kt
+++ b/app/src/main/java/com/example/stylefeed/ui/screens/product/ProductScreenContent.kt
@@ -1,7 +1,11 @@
 package com.example.stylefeed.ui.screens.product
 
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.tooling.preview.Preview
 import com.airbnb.mvrx.Async
 import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading
@@ -12,6 +16,7 @@ import com.example.stylefeed.domain.model.SectionState
 import com.example.stylefeed.designsystem.components.ErrorStateView
 import com.example.stylefeed.designsystem.components.LoadingIndicator
 import com.example.stylefeed.ui.screens.product.components.SuccessContent
+import com.example.stylefeed.ui.screens.product.previewdata.PreviewData
 import com.example.stylefeed.ui.screens.product.viewmodel.ProductEvent
 
 @Composable
@@ -51,3 +56,22 @@ fun ProductScreenContent(
     }
 
 }
+
+@Preview(showBackground = true)
+@Composable
+fun ProductScreenContentPreview() {
+    val sectionHeights = remember { mutableStateMapOf<Int, Float>() }
+    val listState = rememberLazyListState()
+
+    ProductScreenContent(
+        sectionsAsync = Success(PreviewData.allSections), // ✅ 여기만 바꿈!
+        recentlyAddedIds = emptySet(),
+        listState = listState,
+        sectionHeights = sectionHeights,
+        apiError = null,
+        onFooterClick = { _, _, _ -> },
+        onRetryClick = {},
+        sectionLoadingMap = mapOf(0 to false)
+    )
+}
+

--- a/app/src/main/java/com/example/stylefeed/ui/screens/product/components/SuccessContent.kt
+++ b/app/src/main/java/com/example/stylefeed/ui/screens/product/components/SuccessContent.kt
@@ -3,15 +3,19 @@ package com.example.stylefeed.ui.screens.product.components
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import com.example.stylefeed.designsystem.components.AnimatedStickyHeader
 import com.example.stylefeed.domain.model.FooterType
 import com.example.stylefeed.domain.model.SectionState
 import com.example.stylefeed.ui.screens.product.components.sections.SectionsList
 import com.example.stylefeed.ui.screens.product.interactions.rememberStickyHeaderState
+import com.example.stylefeed.ui.screens.product.previewdata.PreviewData
 
 @Composable
 fun SuccessContent(
@@ -37,4 +41,20 @@ fun SuccessContent(
         )
         AnimatedStickyHeader(headerText = currentStickyHeader.value)
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SuccessContentPreview() {
+    val listState = rememberLazyListState()
+    val sectionHeights = remember { mutableStateMapOf<Int, Float>() }
+
+    SuccessContent(
+        sections = PreviewData.allSections,
+        recentlyAddedIds = emptySet(),
+        listState = listState,
+        sectionHeights = sectionHeights,
+        onFooterClick = { _, _, _ -> },
+        sectionLoadingMap = mapOf(0 to false, 1 to true) // 로딩 상태 테스트 가능
+    )
 }

--- a/app/src/main/java/com/example/stylefeed/ui/screens/product/components/sections/ProductSectionView.kt
+++ b/app/src/main/java/com/example/stylefeed/ui/screens/product/components/sections/ProductSectionView.kt
@@ -9,10 +9,10 @@ import com.example.stylefeed.domain.model.FooterType
 import com.example.stylefeed.domain.model.SectionState
 import com.example.stylefeed.domain.model.imageAspectRatio
 import com.example.stylefeed.ui.screens.product.components.banners.BannerSlider
-import com.example.stylefeed.ui.screens.product.components.lists.ProductHorizontalList
+import com.example.stylefeed.ui.screens.product.components.footer.ProductFooter
 import com.example.stylefeed.ui.screens.product.components.grid.ProductGrid
 import com.example.stylefeed.ui.screens.product.components.grid.StyleGrid
-import com.example.stylefeed.ui.screens.product.components.footer.ProductFooter
+import com.example.stylefeed.ui.screens.product.components.lists.ProductHorizontalList
 
 @Composable
 fun SectionView(

--- a/app/src/main/java/com/example/stylefeed/ui/screens/product/components/sections/ProductSectionsList.kt
+++ b/app/src/main/java/com/example/stylefeed/ui/screens/product/components/sections/ProductSectionsList.kt
@@ -7,16 +7,21 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.tooling.preview.Preview
 import com.example.stylefeed.designsystem.theme.Dimensions.ListBottomPadding
+import com.example.stylefeed.designsystem.theme.FashionContentTheme
 import com.example.stylefeed.domain.model.FooterType
 import com.example.stylefeed.domain.model.SectionState
+import com.example.stylefeed.ui.screens.product.previewdata.PreviewData
 
 private const val FadeAnimationDurationMillis = 600
 
@@ -69,5 +74,23 @@ fun SectionsList(
                 }
             }
         }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SectionsListPreview() {
+    val listState = rememberLazyListState()
+    val sectionHeights = remember { mutableStateMapOf<Int, Float>() }
+    FashionContentTheme {
+        SectionsList(
+            sectionStates = PreviewData.allSections.shuffled(), // 🔁 순서 바꿔서 테스트
+            isVisible = true,
+            listState = listState,
+            sectionHeights = sectionHeights,
+            recentlyAddedIds = emptySet(),
+            sectionLoadingMap = mapOf(0 to false, 1 to true), // 로딩 여부 섞어보기
+            onFooterClick = { _, _, _ -> }
+        )
     }
 }

--- a/app/src/main/java/com/example/stylefeed/ui/screens/product/previewdata/PreviewData.kt
+++ b/app/src/main/java/com/example/stylefeed/ui/screens/product/previewdata/PreviewData.kt
@@ -1,0 +1,91 @@
+package com.example.stylefeed.ui.screens.product.previewdata
+
+import com.example.stylefeed.domain.model.*
+
+object PreviewData {
+
+    private val bannerSection = SectionState(
+        section = Section(
+            header = Header("오늘의 배너", null, null),
+            content = Content.BannerContent(
+                banners = listOf(
+                    Banner(
+                        linkUrl = "https://www.musinsa.com/app/plan/views/22278",
+                        thumbnailUrl = "https://image.msscdn.net/images/event_banner/2022062311154900000044053.jpg",
+                        title = "하이드아웃 S/S 시즌오프",
+                        description = "최대 30% 할인",
+                        keyword = "세일"
+                    )
+                )
+            ),
+            footer = null
+        ),
+        visibleItemCount = 1,
+        totalItemCount = 1
+    )
+
+    private val gridSection = SectionState(
+        section = Section(
+            header = Header("클리어런스", null, null),
+            content = Content.GridContent(
+                products = listOf(
+                    Product(
+                        linkUrl = "https://www.musinsa.com/app/goods/2281818",
+                        thumbnailUrl = "https://image.msscdn.net/images/goods_img/20211224/2281818/2281818_1_320.jpg",
+                        brandName = "아스트랄 프로젝션",
+                        formattedPrice = "39,900원",
+                        saleRate = 50,
+                        hasCoupon = true
+                    )
+                )
+            ),
+            footer = Footer(type = FooterType.MORE, title = "더보기", iconUrl = null)
+        ),
+        visibleItemCount = 1,
+        totalItemCount = 5
+    )
+
+    private val scrollSection = SectionState(
+        section = Section(
+            header = Header(
+                title = "디스커버리 익스페디션 인기 스니커즈",
+                iconUrl = "https://image.msscdn.net/icons/mobile/clock.png",
+                linkUrl = "https://www.musinsa.com/brands/discoveryexpedition"
+            ),
+            content = Content.ScrollContent(
+                products = listOf(
+                    Product(
+                        linkUrl = "https://www.musinsa.com/app/goods/1727824",
+                        thumbnailUrl = "https://image.msscdn.net/images/goods_img/20201221/1727824/1727824_4_320.jpg",
+                        brandName = "디스커버리 익스페디션",
+                        formattedPrice = "59,500원",
+                        saleRate = 50,
+                        hasCoupon = true
+                    )
+                )
+            ),
+            footer = Footer(type = FooterType.REFRESH, title = "새로운 추천", iconUrl = null)
+        ),
+        visibleItemCount = 1,
+        totalItemCount = 10
+    )
+
+    private val styleSection = SectionState(
+        section = Section(
+            header = Header("무신사 추천 코디", null, null),
+            content = Content.StyleContent(
+                styles = listOf(
+                    Style(
+                        linkUrl = "https://www.musinsa.com/app/styles/views/27417",
+                        thumbnailUrl = "https://image.musinsa.com/images/style/list/2022062214302100000008217.jpg"
+                    )
+                )
+            ),
+            footer = Footer(FooterType.MORE, "더보기", null)
+        ),
+        visibleItemCount = 1,
+        totalItemCount = 20
+    )
+
+    val allSections = listOf(bannerSection, gridSection, scrollSection, styleSection)
+}

--- a/app/src/main/java/com/example/stylefeed/ui/screens/product/viewmodel/ProductState.kt
+++ b/app/src/main/java/com/example/stylefeed/ui/screens/product/viewmodel/ProductState.kt
@@ -10,5 +10,5 @@ data class ProductState(
     val sections: Async<List<SectionState>> = Uninitialized,
     val recentlyAddedImageUrl: Set<String> = emptySet(),
     override val apiError: ApiError? = null,
-    val sectionLoadingMap: Map<Int, Boolean> = emptyMap()
+    val sectionUiLoadingMap: Map<Int, Boolean> = emptyMap()
 ) : BaseState

--- a/app/src/main/java/com/example/stylefeed/ui/screens/product/viewmodel/ProductViewModel.kt
+++ b/app/src/main/java/com/example/stylefeed/ui/screens/product/viewmodel/ProductViewModel.kt
@@ -85,14 +85,14 @@ class ProductViewModel @AssistedInject constructor(
                 FooterType.REFRESH -> {
                     viewModelScope.launch {
                         setState {
-                            copy(sectionLoadingMap = sectionLoadingMap + (sectionIndex to true))
+                            copy(sectionUiLoadingMap = sectionUiLoadingMap + (sectionIndex to true))
                         }
                         delay(1000)
                         val updatedSections = updateSectionForRefresh(currentSections, sectionIndex)
                         setState {
                             copy(
                                 sections = Success(updatedSections),
-                                sectionLoadingMap = sectionLoadingMap + (sectionIndex to false)
+                                sectionUiLoadingMap = sectionUiLoadingMap + (sectionIndex to false)
                             )
                         }
                         sendEffect(ProductEffect.ShowRefreshSnackBar)


### PR DESCRIPTION
This commit introduces a refresh functionality for product sections, including a loading state and a notification banner.

-   **Product Refresh**:
    -   Implemented refresh functionality for product sections.
    -   Added a loading state to the `RoundedButton` during the refresh operation.
    -   Displayed a toast notification banner when new products are updated.

-   **UI Enhancements**:
    -   Added color filter for footer icons.
    -   Adjusted typography and color scheme for improved UI.
    -   Improved button animations and loading state indication.

-   **Code Refactoring**:
    -   Moved `RefreshNotificationBanner` to a separate component file.
    -   Updated imports and removed unused code.
    -   Cleaned up and organized the code for better readability.